### PR TITLE
fix: restore intro tree links for docusaurus

### DIFF
--- a/.husky/intro/file_counter.sh
+++ b/.husky/intro/file_counter.sh
@@ -1,18 +1,29 @@
 #!/bin/bash
 
-export LC_CTYPE=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
-export LANG="UTF-8"
+export LC_CTYPE=C.UTF-8
+export LC_ALL=C.UTF-8
+export LANG="C.UTF-8"
 filepath=$(git rev-parse --show-toplevel)
 
 function generate_directory_file_counts() {
-  git ls-files '*.md' \
-    | grep -v '^README.md$' \
-    | cut -d/ -f1 \
-    | sort | uniq -c \
-    | while read count dir; do
-        sed -i "s/__${dir}_DIRECTORY_COUNT__/${count}/g" "$filepath/README.md"
-      done
+  local -a targets=(
+    "$filepath/README.md"
+    "$filepath/docs/intro.md"
+  )
 
-  sed -E -i 's/__[A-Za-z0-9_]+_DIRECTORY_COUNT__/0/g' "$filepath/README.md"
+  while read -r count dir; do
+    for target in "${targets[@]}"; do
+      sed -i "s/__${dir}_DIRECTORY_COUNT__/${count}/g" "$target"
+    done
+  done < <(
+    git ls-files '*.md' \
+      | grep -v '^README.md$' \
+      | cut -d/ -f1 \
+      | sort \
+      | uniq -c
+  )
+
+  for target in "${targets[@]}"; do
+    sed -E -i 's/__[A-Za-z0-9_]+_DIRECTORY_COUNT__/0/g' "$target"
+  done
 }

--- a/.husky/intro/intro_generater.sh
+++ b/.husky/intro/intro_generater.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-export LC_CTYPE=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
-export LANG="UTF-8"
+export LC_CTYPE=C.UTF-8
+export LC_ALL=C.UTF-8
+export LANG="C.UTF-8"
 filepath=$(git rev-parse --show-toplevel)
 intro="$filepath/docs/intro.md"
 
@@ -10,9 +10,9 @@ function generate_intro() {
   intro_template="$filepath/.husky/intro/intro_template.md"
   cp -f "$intro_template" "$intro"
 
-  generate_project_tree . |
-    proejct_tree_formatter |
-    LANG="UTF-8" perl -p0e 's/__PROJECT_TREE__/`cat`/se' -i "$intro"
+  generate_project_tree \
+    | proejct_tree_formatter \
+    | LANG="C.UTF-8" perl -p0e 's/__PROJECT_TREE__/`cat`/se' -i "$intro"
 
   generate_directory_file_counts
 }

--- a/.husky/intro/setting.json
+++ b/.husky/intro/setting.json
@@ -1,7 +1,9 @@
 {
     "ignore_files": [
+      ".github",
       ".husky",
       ".idx",
+      ".vscode",
       "node_modules",
       ".gitignore",
       "package-lock.json",

--- a/.husky/intro/tree_generater.sh
+++ b/.husky/intro/tree_generater.sh
@@ -1,32 +1,14 @@
 #!/bin/bash
 
-export LC_CTYPE=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
-export LANG="UTF-8"
+export LC_CTYPE=C.UTF-8
+export LC_ALL=C.UTF-8
+export LANG="C.UTF-8"
 filepath=$(git rev-parse --show-toplevel)
-ignore_files=$(jq -r '.ignore_files | join("|")' "$filepath"/.husky/intro/setting.json)
 
 function generate_project_tree() {
-  tree ./docs -I "$ignore_files" -P "*.md" -f --dirsfirst --noreport --prune -I '~'
+  python3 "$filepath/.husky/intro/tree_generator.py" "$filepath"
 }
 
 function proejct_tree_formatter() {
-  while IFS= read line; do
-    echo "$line" |
-      sed -e 's/[|]-\+/┗/g' |
-      sed -e 's/[│]/┃/g' |
-      sed -e 's/[└]/┗/g' |
-      sed -e 's/[├]/┣/g' |
-      sed -e 's/[─]/━/g' |
-      sed -e "s:\(━ \+\)\(\(.*/\)\([^/]\+\)\):\1📂[**\4**](\2)<\/br>:g" |
-      sed -e "s:\[\*\*\(.*\)\.md\*\*\]:📄\[**\1\**]:g" |
-      sed -e "s=$filepath/=./=g" |
-      sed -e "s=$filepath=./TIL</br>=g" |
-      sed -e 's/━━/━/g' |
-      sed -e 's/[/docs]//g' |
-      sed -e "s=^\.=📦[**TIL**](./docs)</br>=" |
-      sed -e 's/ /\&nbsp;\&nbsp;/g' |
-      sed -e 's/&nbsp;📂/📂/g' |
-      sed -e 's/📂📄/📄/g'
-  done
+  cat
 }

--- a/.husky/intro/tree_generator.py
+++ b/.husky/intro/tree_generator.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+ROOT = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path.cwd()
+SETTING_PATH = ROOT / ".husky" / "intro" / "setting.json"
+
+with SETTING_PATH.open(encoding="utf-8") as fp:
+    settings = json.load(fp)
+
+IGNORE_NAMES = set(settings.get("ignore_files", []))
+
+
+def should_ignore(path: Path) -> bool:
+    if path == ROOT:
+        return False
+
+    try:
+        relative = path.relative_to(ROOT)
+    except ValueError:
+        return True
+
+    for part in relative.parts:
+        if part in IGNORE_NAMES:
+            return True
+    return False
+
+
+def collect_entries(path: Path) -> List[Tuple[str, Path, List[Tuple]]]:
+    entries: List[Tuple[str, Path, List[Tuple]]] = []
+
+    children = sorted(
+        path.iterdir(),
+        key=lambda p: (p.is_file(), p.name.lower()),
+    )
+
+    for child in children:
+        if should_ignore(child):
+            continue
+        if child.is_dir():
+            child_entries = collect_entries(child)
+            if child_entries:
+                entries.append(("dir", child, child_entries))
+        elif child.suffix.lower() == ".md":
+            entries.append(("file", child, []))
+    return entries
+
+
+def render(entries: Iterable[Tuple[str, Path, List[Tuple]]], ancestors: List[bool]) -> List[str]:
+    lines: List[str] = []
+    for index, (kind, node_path, children) in enumerate(entries):
+        is_last = index == len(entries) - 1
+        parts: List[str] = []
+        for ancestor_last in ancestors:
+            parts.append("&nbsp;&nbsp;&nbsp;&nbsp;" if ancestor_last else "┃&nbsp;&nbsp;")
+
+        connector = "┗━" if is_last else "┣━"
+        rel_path = node_path.relative_to(ROOT).as_posix()
+        label = node_path.stem if kind == "file" else node_path.name
+        icon = "📄" if kind == "file" else "📂"
+        line = f"{''.join(parts)}{connector}&nbsp;{icon}[**{label}**](./{rel_path})</br>"
+        lines.append(line)
+
+        if kind == "dir":
+            lines.extend(render(children, ancestors + [is_last]))
+    return lines
+
+
+def main() -> None:
+    entries = collect_entries(ROOT)
+    print("📦[**TIL**](./)</br>")
+    for line in render(entries, []):
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -4,17 +4,17 @@
 
 | Directory         | Content                              | Count                        |
 | ----------------- | :----------------------------------- | ---------------------------- |
-| AI_ML             | 인공지능과 머신러닝과 관련된 내용       | __AI_ML_DIRECTORY_COUNT__    |
-| Backend           | 백엔드 프레임워크와 관련된 내용         | __Backend_DIRECTORY_COUNT__  |
-| Cloud             | 클라우드 컴퓨팅과 관련된 내용           | __Cloud_DIRECTORY_COUNT__    |
-| DevGeneral        | 디자인 패턴, 방법론 등의 내용          | __DevGeneral_DIRECTORY_COUNT__|
-| DevOps            | DevOps와 관련된 내용                  | __DevOps_DIRECTORY_COUNT__   |
-| Databases         | 데이터베이스와 관련된 내용             | __Databases_DIRECTORY_COUNT__|
-| Frontend          | 프론트 프레임워크와 관련된 내용        | __Frontend_DIRECTORY_COUNT__ |
-| Languages         | 다양한 프로그래밍 언어와 관련된 내용    | __Languages_DIRECTORY_COUNT__|
-| Networking        | 네트워킹과 관련된 내용                 | __Networking_DIRECTORY_COUNT__|
-| OperatingSystems  | 운영 체제와 관련된 내용                | __OperatingSystems_DIRECTORY_COUNT__|
-| Security          | 보안과 관련된 내용                    | __Security_DIRECTORY_COUNT__|
+| AI_ML             | 인공지능과 머신러닝과 관련된 내용       | 0    |
+| Backend           | 백엔드 프레임워크와 관련된 내용         | 6  |
+| Cloud             | 클라우드 컴퓨팅과 관련된 내용           | 1    |
+| DevGeneral        | 디자인 패턴, 방법론 등의 내용          | 8|
+| DevOps            | DevOps와 관련된 내용                  | 3   |
+| Databases         | 데이터베이스와 관련된 내용             | 0|
+| Frontend          | 프론트 프레임워크와 관련된 내용        | 0 |
+| Languages         | 다양한 프로그래밍 언어와 관련된 내용    | 32|
+| Networking        | 네트워킹과 관련된 내용                 | 6|
+| OperatingSystems  | 운영 체제와 관련된 내용                | 1|
+| Security          | 보안과 관련된 내용                    | 0|
 
 해당 TIL은 아래의 자료들의 영향을 받았습니다.
 - [jbrnchaud/til](https://github.com/jbranchaud/til)
@@ -48,103 +48,95 @@
 
 ## File Tree
 
-📦[**TIL**](./docs)</br>
-┣━&nbsp;📂[**Baken**](.Baken)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📂[**NetJS**](.BakenNetJS)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**Requet_Lifeyle**](.BakenNetJSRequet_Lifeyle.m)<br>
-┃  &nbsp;&nbsp;┗━&nbsp;📂[**npm**](.Bakennpm)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📂[**pakage_jn**](.Bakennpmpakage_jn)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**epenenie_flie**](.Bakennpmpakage_jnepenenie_flie.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**env_publih_fiel**](.Bakennpmpakage_jnenv_publih_fiel.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**meta_fiel**](.Bakennpmpakage_jnmeta_fiel.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**runtime_i_fiel**](.Bakennpmpakage_jnruntime_i_fiel.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Semanti_verin**](.BakennpmSemanti_verin.m)<br>
-┣━&nbsp;📂[**Clu**](.Clu)<br>
-┃  &nbsp;&nbsp;┗━&nbsp;📂[**AWS**](.CluAWS)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**EC2**](.CluAWSEC2.m)<br>
-┣━&nbsp;📂[**DevGeneral**](.DevGeneral)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📂[**Agile**](.DevGeneralAgile)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**SftwareCraftmanhipManifet**](.DevGeneralAgileSftwareCraftmanhipManifet.m)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📂[**Algrithm**](.DevGeneralAlgrithm)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📂[**Srt**](.DevGeneralAlgrithmSrt)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Merge_Srt**](.DevGeneralAlgrithmSrtMerge_Srt.m)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📂[**DeignPattern**](.DevGeneralDeignPattern)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**Stati_Fatry_Meth**](.DevGeneralDeignPatternStati_Fatry_Meth.m)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📂[**IEEE**](.DevGeneralIEEE)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**IEEE_754_Flating_Pint**](.DevGeneralIEEEIEEE_754_Flating_Pint.m)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📂[**Priniple**](.DevGeneralPriniple)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**Tw_Hat**](.DevGeneralPrinipleTw_Hat.m)<br>
-┃  &nbsp;&nbsp;┗━&nbsp;📂[**Refatring**](.DevGeneralRefatring)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Definitin_f_Refatring**](.DevGeneralRefatringDefinitin_f_Refatring.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Rean_fr_Refatring**](.DevGeneralRefatringRean_fr_Refatring.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**When_t_Refatring**](.DevGeneralRefatringWhen_t_Refatring.m)<br>
-┣━&nbsp;📂[**DevOp**](.DevOp)<br>
-┃  &nbsp;&nbsp;┗━&nbsp;📂[**Pulumi**](.DevOpPulumi)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Prjet**](.DevOpPulumiPrjet.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Pulumi**](.DevOpPulumiPulumi.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Stak**](.DevOpPulumiStak.m)<br>
-┣━&nbsp;📂[**Language**](.Language)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📂[**JavaSript**](.LanguageJavaSript)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📂[**DataStruture**](.LanguageJavaSriptDataStruture)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Jn**](.LanguageJavaSriptDataStrutureJn.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**Map**](.LanguageJavaSriptDataStrutureMap.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📂[**DataType**](.LanguageJavaSriptDataType)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**BigInt**](.LanguageJavaSriptDataTypeBigInt.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Blean**](.LanguageJavaSriptDataTypeBlean.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Null**](.LanguageJavaSriptDataTypeNull.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Number**](.LanguageJavaSriptDataTypeNumber.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Number_Type_Iue**](.LanguageJavaSriptDataTypeNumber_Type_Iue.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**String**](.LanguageJavaSriptDataTypeString.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Symbl**](.LanguageJavaSriptDataTypeSymbl.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Typef**](.LanguageJavaSriptDataTypeTypef.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**Unefine**](.LanguageJavaSriptDataTypeUnefine.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📂[**Engine**](.LanguageJavaSriptEngine)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Exeutin_Cntext**](.LanguageJavaSriptEngineExeutin_Cntext.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Intrutin_t_JavaSript_Engine**](.LanguageJavaSriptEngineIntrutin_t_JavaSript_Engine.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**JavaSript_Cmpilatin_Pre**](.LanguageJavaSriptEngineJavaSript_Cmpilatin_Pre.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**Parer_An_AST**](.LanguageJavaSriptEngineParer_An_AST.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📂[**Funtin**](.LanguageJavaSriptFuntin)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Arrw_Funtin**](.LanguageJavaSriptFuntinArrw_Funtin.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**Funtin**](.LanguageJavaSriptFuntinFuntin.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📂[**Intrutin**](.LanguageJavaSriptIntrutin)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Hitry_f_JavaSript**](.LanguageJavaSriptIntrutinHitry_f_JavaSript.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**What_i_JavaSript**](.LanguageJavaSriptIntrutinWhat_i_JavaSript.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📂[**JSD**](.LanguageJavaSriptJSD)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**JSD**](.LanguageJavaSriptJSDJSD.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📂[**Objet**](.LanguageJavaSriptObjet)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Built-in_Objet**](.LanguageJavaSriptObjetBuilt-in_Objet.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Objet**](.LanguageJavaSriptObjetObjet.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**ObjetPrttype**](.LanguageJavaSriptObjetObjetPrttype.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**Prttypal_Inheritane**](.LanguageJavaSriptObjetPrttypal_Inheritane.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📂[**TypeCating**](.LanguageJavaSriptTypeCating)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┣━&nbsp;📄[**Expliit_Type_Cating**](.LanguageJavaSriptTypeCatingExpliit_Type_Cating.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📄[**Impliit_Type_Cating**](.LanguageJavaSriptTypeCatingImpliit_Type_Cating.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;┗━&nbsp;📂[**Variable**](.LanguageJavaSriptVariable)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Cnt**](.LanguageJavaSriptVariableCnt.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Hiting**](.LanguageJavaSriptVariableHiting.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Let**](.LanguageJavaSriptVariableLet.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Spe**](.LanguageJavaSriptVariableSpe.m)<br>
-┃  &nbsp;&nbsp;┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Var**](.LanguageJavaSriptVariableVar.m)<br>
-┃  &nbsp;&nbsp;┗━&nbsp;📂[**TypeSript**](.LanguageTypeSript)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Cnt_Aertin**](.LanguageTypeSriptCnt_Aertin.m)<br>
-┣━&nbsp;📂[**Netwrking**](.Netwrking)<br>
-┃  &nbsp;&nbsp;┗━&nbsp;📂[**HTTP**](.NetwrkingHTTP)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Chunke_Tranfer-Ening**](.NetwrkingHTTPChunke_Tranfer-Ening.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**HTTP_0.9-t-1.1**](.NetwrkingHTTPHTTP_0.9-t-1.1.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**HTTP_Generi_Meage**](.NetwrkingHTTPHTTP_Generi_Meage.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**HTTP_ht-heaer**](.NetwrkingHTTPHTTP_ht-heaer.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**HTTP_Keep-Alive**](.NetwrkingHTTPHTTP_Keep-Alive.m)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Meage_Start_Line**](.NetwrkingHTTPMeage_Start_Line.m)<br>
-┣━&nbsp;📂[**OperatingSytem**](.OperatingSytem)<br>
-┃  &nbsp;&nbsp;┗━&nbsp;📂[**Linux**](.OperatingSytemLinux)<br>
-┃  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**tree**](.OperatingSytemLinuxtree.m)<br>
-┣━&nbsp;📂[**tutrial-bai**](.tutrial-bai)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📄[**ngratulatin**](.tutrial-baingratulatin.m)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📄[**reate-a-blg-pt**](.tutrial-baireate-a-blg-pt.m)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📄[**reate-a-ument**](.tutrial-baireate-a-ument.m)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📄[**reate-a-page**](.tutrial-baireate-a-page.m)<br>
-┃  &nbsp;&nbsp;┗━&nbsp;📄[**eply-yur-ite**](.tutrial-baieply-yur-ite.m)<br>
-┣━&nbsp;📂[**tutrial-extra**](.tutrial-extra)<br>
-┃  &nbsp;&nbsp;┣━&nbsp;📄[**manage--verin**](.tutrial-extramanage--verin.m)<br>
-┃  &nbsp;&nbsp;┗━&nbsp;📄[**tranlate-yur-ite**](.tutrial-extratranlate-yur-ite.m)<br>
-┗━&nbsp;📄[**intr**](.intr.m)<br>
+📦[**TIL**](./)</br>
+┣━&nbsp;📂[**Backend**](./Backend)</br>
+┃&nbsp;&nbsp;┣━&nbsp;📂[**NestJS**](./Backend/NestJS)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**Request_Lifecycle**](./Backend/NestJS/Request_Lifecycle.md)</br>
+┃&nbsp;&nbsp;┗━&nbsp;📂[**npm**](./Backend/npm)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📂[**package_json**](./Backend/npm/package_json)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**dependencies_flieds**](./Backend/npm/package_json/dependencies_flieds.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**env_publish_fields**](./Backend/npm/package_json/env_publish_fields.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**meta_fields**](./Backend/npm/package_json/meta_fields.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**runtime_io_fields**](./Backend/npm/package_json/runtime_io_fields.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Semantic_version**](./Backend/npm/Semantic_version.md)</br>
+┣━&nbsp;📂[**Cloud**](./Cloud)</br>
+┃&nbsp;&nbsp;┗━&nbsp;📂[**AWS**](./Cloud/AWS)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**EC2**](./Cloud/AWS/EC2.md)</br>
+┣━&nbsp;📂[**DevGeneral**](./DevGeneral)</br>
+┃&nbsp;&nbsp;┣━&nbsp;📂[**Agile**](./DevGeneral/Agile)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**SoftwareCraftsmanshipManifesto**](./DevGeneral/Agile/SoftwareCraftsmanshipManifesto.md)</br>
+┃&nbsp;&nbsp;┣━&nbsp;📂[**Algorithm**](./DevGeneral/Algorithm)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📂[**Sort**](./DevGeneral/Algorithm/Sort)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Merge_Sort**](./DevGeneral/Algorithm/Sort/Merge_Sort.md)</br>
+┃&nbsp;&nbsp;┣━&nbsp;📂[**DesignPatterns**](./DevGeneral/DesignPatterns)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**Static_Factory_Method**](./DevGeneral/DesignPatterns/Static_Factory_Method.md)</br>
+┃&nbsp;&nbsp;┣━&nbsp;📂[**IEEE**](./DevGeneral/IEEE)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**IEEE_754_Floating_Point**](./DevGeneral/IEEE/IEEE_754_Floating_Point.md)</br>
+┃&nbsp;&nbsp;┣━&nbsp;📂[**Principle**](./DevGeneral/Principle)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**Two_Hats**](./DevGeneral/Principle/Two_Hats.md)</br>
+┃&nbsp;&nbsp;┗━&nbsp;📂[**Refactoring**](./DevGeneral/Refactoring)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Definition_of_Refactoring**](./DevGeneral/Refactoring/Definition_of_Refactoring.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Reasons_for_Refactoring**](./DevGeneral/Refactoring/Reasons_for_Refactoring.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**When_to_Refactoring**](./DevGeneral/Refactoring/When_to_Refactoring.md)</br>
+┣━&nbsp;📂[**DevOps**](./DevOps)</br>
+┃&nbsp;&nbsp;┗━&nbsp;📂[**Pulumi**](./DevOps/Pulumi)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Project**](./DevOps/Pulumi/Project.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Pulumi**](./DevOps/Pulumi/Pulumi.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Stack**](./DevOps/Pulumi/Stack.md)</br>
+┣━&nbsp;📂[**docs**](./docs)</br>
+┃&nbsp;&nbsp;┗━&nbsp;📄[**intro**](./docs/intro.md)</br>
+┣━&nbsp;📂[**Languages**](./Languages)</br>
+┃&nbsp;&nbsp;┣━&nbsp;📂[**JavaScript**](./Languages/JavaScript)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📂[**DataStructures**](./Languages/JavaScript/DataStructures)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Json**](./Languages/JavaScript/DataStructures/Json.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**Map**](./Languages/JavaScript/DataStructures/Map.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📂[**DataTypes**](./Languages/JavaScript/DataTypes)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**BigInt**](./Languages/JavaScript/DataTypes/BigInt.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Boolean**](./Languages/JavaScript/DataTypes/Boolean.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Null**](./Languages/JavaScript/DataTypes/Null.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Number**](./Languages/JavaScript/DataTypes/Number.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Number_Type_Issues**](./Languages/JavaScript/DataTypes/Number_Type_Issues.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**String**](./Languages/JavaScript/DataTypes/String.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Symbol**](./Languages/JavaScript/DataTypes/Symbol.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Typeof**](./Languages/JavaScript/DataTypes/Typeof.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**Undefined**](./Languages/JavaScript/DataTypes/Undefined.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📂[**Engine**](./Languages/JavaScript/Engine)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Execution_Context**](./Languages/JavaScript/Engine/Execution_Context.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Introduction_to_JavaScript_Engine**](./Languages/JavaScript/Engine/Introduction_to_JavaScript_Engine.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**JavaScript_Compilation_Process**](./Languages/JavaScript/Engine/JavaScript_Compilation_Process.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**Parser_And_AST**](./Languages/JavaScript/Engine/Parser_And_AST.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📂[**Functions**](./Languages/JavaScript/Functions)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Arrow_Function**](./Languages/JavaScript/Functions/Arrow_Function.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**Function**](./Languages/JavaScript/Functions/Function.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📂[**Introdution**](./Languages/JavaScript/Introdution)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**History_of_JavaScript**](./Languages/JavaScript/Introdution/History_of_JavaScript.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**What_is_JavaScript**](./Languages/JavaScript/Introdution/What_is_JavaScript.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📂[**JSDoc**](./Languages/JavaScript/JSDoc)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**JSDoc**](./Languages/JavaScript/JSDoc/JSDoc.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📂[**Object**](./Languages/JavaScript/Object)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Built-in_Object**](./Languages/JavaScript/Object/Built-in_Object.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Object**](./Languages/JavaScript/Object/Object.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**ObjectPrototype**](./Languages/JavaScript/Object/ObjectPrototype.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**Prototypal_Inheritance**](./Languages/JavaScript/Object/Prototypal_Inheritance.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📂[**TypeCasting**](./Languages/JavaScript/TypeCasting)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┣━&nbsp;📄[**Explicit_Type_Casting**](./Languages/JavaScript/TypeCasting/Explicit_Type_Casting.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📄[**Implicit_Type_Casting**](./Languages/JavaScript/TypeCasting/Implicit_Type_Casting.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;┗━&nbsp;📂[**Variables**](./Languages/JavaScript/Variables)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Const**](./Languages/JavaScript/Variables/Const.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Hoisting**](./Languages/JavaScript/Variables/Hoisting.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Let**](./Languages/JavaScript/Variables/Let.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Scope**](./Languages/JavaScript/Variables/Scope.md)</br>
+┃&nbsp;&nbsp;┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Var**](./Languages/JavaScript/Variables/Var.md)</br>
+┃&nbsp;&nbsp;┗━&nbsp;📂[**TypeScript**](./Languages/TypeScript)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Const_Assertion**](./Languages/TypeScript/Const_Assertion.md)</br>
+┣━&nbsp;📂[**Networking**](./Networking)</br>
+┃&nbsp;&nbsp;┗━&nbsp;📂[**HTTP**](./Networking/HTTP)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**Chunked_Transfer-Encoding**](./Networking/HTTP/Chunked_Transfer-Encoding.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**HTTP_0.9-to-1.1**](./Networking/HTTP/HTTP_0.9-to-1.1.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**HTTP_Generic_Message**](./Networking/HTTP/HTTP_Generic_Message.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**HTTP_host-header**](./Networking/HTTP/HTTP_host-header.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┣━&nbsp;📄[**HTTP_Keep-Alive**](./Networking/HTTP/HTTP_Keep-Alive.md)</br>
+┃&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**Message_Start_Line**](./Networking/HTTP/Message_Start_Line.md)</br>
+┗━&nbsp;📂[**OperatingSystems**](./OperatingSystems)</br>
+&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📂[**Linux**](./OperatingSystems/Linux)</br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;┗━&nbsp;📄[**tree**](./OperatingSystems/Linux/tree.md)</br>


### PR DESCRIPTION
## Summary
- replace the brittle tree-formatting sed pipeline with a Python generator so intro links stay intact for Docusaurus
- update the Husky helper scripts and ignore list to use the new generator and refresh both README and docs counts
- regenerate docs/intro.md so the file tree now contains valid Markdown links for every tracked note

## Testing
- `bash -lc 'set -e; source .husky/intro/tree_generater.sh; source .husky/intro/file_counter.sh; source .husky/intro/intro_generater.sh; generate_intro'`


------
https://chatgpt.com/codex/tasks/task_e_68d2acf4615c83309321a2db7fee017c